### PR TITLE
update mafglib & bocchud version

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -34,10 +34,10 @@ dependencies {
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
 
-    modApi 'curse.maven:bocchud-916504:5068969' // 0.1.2-mc1.20.1
+    modApi 'maven.modrinth:bocchud:0.1.6-mc1.20.1' // 0.1.6-mc1.20.1
     modApi 'curse.maven:ftb-library-404465:5051953' // forge-2001.1.5
     modApi 'curse.maven:ftb-ultimine-386134:5005006' // forge-2001.1.4
-    modApi 'curse.maven:mafglib-910766:5068815' // 0.1.8-mc1.20.1
+    modApi 'maven.modrinth:mafglib:0.1.11-mc1.20.1' // 0.1.11-mc1.20.1
     modApi 'curse.maven:mekanism-268560:5125665' // 1.20.1-10.4.6.20
     modApi 'curse.maven:mekanism-generators-268566:5125668' // 1.20.1-10.4.6.20
     modApi 'curse.maven:serene-seasons-291874:4761603' // 1.20.1-9.0.0.46

--- a/forge/src/main/java/com/ecaree/minihudextra/forge/MiniHUDExtraForge.java
+++ b/forge/src/main/java/com/ecaree/minihudextra/forge/MiniHUDExtraForge.java
@@ -3,12 +3,12 @@ package com.ecaree.minihudextra.forge;
 import com.ecaree.minihudextra.InitHandler;
 import com.ecaree.minihudextra.MiniHUDExtra;
 import com.ecaree.minihudextra.config.GuiConfigs;
-import fi.dy.masa.malilib.compat.forge.ForgePlatformCompat;
 import fi.dy.masa.malilib.event.InitializationHandler;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.thinkingstudio.mafglib.util.ForgePlatformUtils;
 
 @Mod(MiniHUDExtra.MOD_ID)
 public class MiniHUDExtraForge {
@@ -17,10 +17,11 @@ public class MiniHUDExtraForge {
         modEventBus.addListener(this::onInitializeClient);
         MiniHUDExtra.init();
     }
+
     public void onInitializeClient(FMLClientSetupEvent event) {
-        ForgePlatformCompat.getInstance().getModClientExtensionPoint();
+        ForgePlatformUtils.getInstance().getClientModIgnoredServerOnly();
         InitializationHandler.getInstance().registerInitializationHandler(new InitHandler());
-        ForgePlatformCompat.getInstance().getMod(MiniHUDExtra.MOD_ID).registerModConfigScreen((screen) -> {
+        ForgePlatformUtils.getInstance().registerModConfigScreen(MiniHUDExtra.MOD_ID, screen -> {
             GuiConfigs gui = new GuiConfigs();
             gui.setParent(screen);
             return gui;

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,5 +33,5 @@ neoforge_loader_version_range=[2,)
 
 architectury_dependency=9.2.14
 minihud_dependency=0.27.0
-bocchud_dependency=0.1.0-mc1.20.4
-forge_bocchud_dependency=0.1.2-mc1.20.1
+bocchud_dependency=0.1.2-mc1.20.4
+forge_bocchud_dependency=0.1.6-mc1.20.1

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -26,11 +26,11 @@ dependencies {
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionNeoForge")) { transitive = false }
 
-    modApi 'curse.maven:bocchud-916504:5122675' // 0.1.0-mc1.20.4
+    modApi "maven.modrinth:bocchud:0.1.2-mc1.20.4" // 0.1.2-mc1.20.4
     modApi 'curse.maven:ftb-library-404465:5205161' // neoforge-2004.2.1
     modApi 'curse.maven:ftb-ultimine-386134:5204156' // neoforge-2004.1.0
-    modApi 'maven.modrinth:mafglib:0.1.4-mc1.20.4' // 0.1.4-mc1.20.4
-    modApi 'com.github.ThinkingStudios:ForgedNetworkingAPI:0.1.0-mc1.20.4'
+    modApi 'maven.modrinth:mafglib:0.1.8-mc1.20.4' // 0.1.8-mc1.20.4
+    modApi 'maven.modrinth:forged-networking-api:0.1.2+mc1.20.4'
     modApi 'curse.maven:mekanism-268560:5257006' // 1.20.4-10.5.19.40
     modApi 'curse.maven:mekanism-generators-268566:5257009' // 1.20.4-10.5.19.40
     modApi 'curse.maven:glitchcore-955399:5088442' // NeoForge 1.20.4-1.0.0.59

--- a/neoforge/src/main/java/com/ecaree/minihudextra/neoforge/MiniHUDExtraNeoForge.java
+++ b/neoforge/src/main/java/com/ecaree/minihudextra/neoforge/MiniHUDExtraNeoForge.java
@@ -3,11 +3,11 @@ package com.ecaree.minihudextra.neoforge;
 import com.ecaree.minihudextra.InitHandler;
 import com.ecaree.minihudextra.MiniHUDExtra;
 import com.ecaree.minihudextra.config.GuiConfigs;
-import fi.dy.masa.malilib.compat.neoforge.ForgePlatformUtils;
 import fi.dy.masa.malilib.event.InitializationHandler;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import org.thinkingstudio.mafglib.util.ForgePlatformUtils;
 
 @Mod(MiniHUDExtra.MOD_ID)
 public class MiniHUDExtraNeoForge {
@@ -15,10 +15,11 @@ public class MiniHUDExtraNeoForge {
         modEventBus.addListener(this::onInitializeClient);
         MiniHUDExtra.init();
     }
+
     public void onInitializeClient(FMLClientSetupEvent event) {
         ForgePlatformUtils.getInstance().getClientModIgnoredServerOnly();
         InitializationHandler.getInstance().registerInitializationHandler(new InitHandler());
-        ForgePlatformUtils.getInstance().getMod(MiniHUDExtra.MOD_ID).registerModConfigScreen((screen) -> {
+        ForgePlatformUtils.getInstance().registerModConfigScreen(MiniHUDExtra.MOD_ID, screen -> {
             GuiConfigs gui = new GuiConfigs();
             gui.setParent(screen);
             return gui;


### PR DESCRIPTION
The `ForgePlatformUtils` class has been migrated from `fi.dy.masa.malilib.compat` to `org.thinkingstudio.mafglib.util` in mafglib 0.1.10 and above, with changes to the ` ForgePlatformUtils.registerModConfigScreen` method.